### PR TITLE
Register base operations.

### DIFF
--- a/base/utils/register/count_leading_zeros_base.hpp
+++ b/base/utils/register/count_leading_zeros_base.hpp
@@ -1,0 +1,21 @@
+#ifndef _COUNT_LEADING_ZEROS_BASE_HPP
+#define _COUNT_LEADING_ZEROS_BASE_HPP
+
+#include "register.hpp"
+
+namespace hunos {
+namespace base {
+namespace utils {
+inline namespace reg {
+
+template <typename T>
+uint8_t countLeadingZeros(T value);
+
+}  // namespace reg
+}  // namespace utils
+}  // namespace base
+}  // namespace hunos
+
+#include "count_leading_zeros_base_impl.hpp"
+
+#endif

--- a/base/utils/register/count_leading_zeros_base_impl.hpp
+++ b/base/utils/register/count_leading_zeros_base_impl.hpp
@@ -1,0 +1,25 @@
+#include "count_leading_zeros_base.hpp"
+
+namespace hunos {
+namespace base {
+namespace utils {
+inline namespace reg {
+
+template <typename T>
+uint8_t countLeadingZeros(T value){
+	const T mask = (T) (1 << (BIT_SIZEOF(T) - 1));
+	uint8_t zeros = 0;
+
+	while((value & mask) == 0 && zeros < BIT_SIZEOF(T)){
+		value = value << 1;
+
+		++zeros;
+	}
+
+	return zeros;
+}
+
+}  // namespace reg
+}  // namespace utils
+}  // namespace base
+}  // namespace hunos

--- a/base/utils/register/count_ones_base.hpp
+++ b/base/utils/register/count_ones_base.hpp
@@ -1,0 +1,21 @@
+#ifndef _COUNT_ONES_BASE_HPP
+#define _COUNT_ONES_BASE_HPP
+
+#include "register.hpp"
+
+namespace hunos {
+namespace base {
+namespace utils {
+inline namespace reg {
+
+template <typename T>
+uint8_t countOnes(T value);
+
+}  // namespace reg
+}  // namespace utils
+}  // namespace base
+}  // namespace hunos
+
+#include "count_ones_base_impl.hpp"
+
+#endif

--- a/base/utils/register/count_ones_base_impl.hpp
+++ b/base/utils/register/count_ones_base_impl.hpp
@@ -1,0 +1,26 @@
+#include "count_ones_base.hpp"
+
+namespace hunos {
+namespace base {
+namespace utils {
+inline namespace reg {
+
+template <typename T>
+uint8_t countOnes(T value){
+	uint8_t bit = 0;
+	uint8_t ones = 0;
+
+	while(bit < BIT_SIZEOF(T)){
+		ones += (value & 1);
+		++bit;
+
+		value = value >> 1;
+	}
+
+	return ones;
+}
+
+}  // namespace reg
+}  // namespace utils
+}  // namespace base
+}  // namespace hunos

--- a/base/utils/register/count_trailing_zeros_base.hpp
+++ b/base/utils/register/count_trailing_zeros_base.hpp
@@ -1,0 +1,21 @@
+#ifndef _COUNT_TRAILING_ZEROS_BASE_HPP
+#define _COUNT_TRAILING_ZEROS_BASE_HPP
+
+#include "register.hpp"
+
+namespace hunos {
+namespace base {
+namespace utils {
+inline namespace reg {
+
+template <typename T>
+uint8_t countTrailingZeros(T value);
+
+}  // namespace reg
+}  // namespace utils
+}  // namespace base
+}  // namespace hunos
+
+#include "count_trailing_zeros_base_impl.hpp"
+
+#endif

--- a/base/utils/register/count_trailing_zeros_base_impl.hpp
+++ b/base/utils/register/count_trailing_zeros_base_impl.hpp
@@ -1,0 +1,24 @@
+#include "count_trailing_zeros_base.hpp"
+
+namespace hunos {
+namespace base {
+namespace utils {
+inline namespace reg {
+
+template <typename T>
+uint8_t countTrailingZeros(T value){
+	uint8_t zeros = 0;
+
+	while((value & 1) == 0 && zeros < BIT_SIZEOF(T)){
+		value = value >> 1;
+
+		++zeros;
+	}
+
+	return zeros;
+}
+
+}  // namespace reg
+}  // namespace utils
+}  // namespace base
+}  // namespace hunos

--- a/base/utils/register/parity_base.hpp
+++ b/base/utils/register/parity_base.hpp
@@ -1,0 +1,21 @@
+#ifndef _PARITY_BASE_HPP
+#define _PARITY_BASE_HPP
+
+#include "register.hpp"
+
+namespace hunos {
+namespace base {
+namespace utils {
+inline namespace reg {
+
+template <typename T>
+bool parity(T value);
+
+}  // namespace reg
+}  // namespace utils
+}  // namespace base
+}  // namespace hunos
+
+#include "parity_base_impl.hpp"
+
+#endif

--- a/base/utils/register/parity_base_impl.hpp
+++ b/base/utils/register/parity_base_impl.hpp
@@ -1,0 +1,19 @@
+#include "parity_base.hpp"
+#include "count_ones_base.hpp"
+
+namespace hunos {
+namespace base {
+namespace utils {
+inline namespace reg {
+
+template <typename T>
+bool parity(T value){
+	uint8_t ones = countOnes<T>(value);
+
+	return (bool) (ones % 2);
+}
+
+}  // namespace reg
+}  // namespace utils
+}  // namespace base
+}  // namespace hunos

--- a/base/utils/register/register.hpp
+++ b/base/utils/register/register.hpp
@@ -1,0 +1,87 @@
+#ifndef _UTILS_REGISTER_HPP
+#define _UTILS_REGISTER_HPP
+
+#include "system/typedefs.hpp"
+
+#define BIT_SIZEOF(a) (sizeof(a) << 3)
+
+namespace hunos {
+namespace utils {
+inline namespace reg {
+
+template <typename T>
+inline T clearBit(const register T value, const register uint8_t bit);
+
+template <typename T>
+inline T setBit(const register T val, const register uint8_t bit);
+
+template <typename T>
+inline T generateLeadingMask(const register uint8_t start_bit);
+
+template <typename T>
+inline T generateTrailingMask(const register uint8_t end_bit);
+
+template <typename T>
+inline uint8_t countLeadingZeros(const register T value);
+
+template <>
+inline uint8_t countLeadingZeros<uint32_t>(const register uint32_t value);
+
+template <>
+inline uint8_t countLeadingZeros<uint64_t>(const register uint64_t value);
+
+template <typename T>
+inline uint8_t countTrailingZeros(const register T value);
+
+template <>
+inline uint8_t countTrailingZeros<uint32_t>(const register uint32_t value);
+
+template <>
+inline uint8_t countTrailingZeros<uint64_t>(const register uint64_t value);
+
+template <typename T>
+inline uint8_t countLeadingOnes(const register T value);
+
+template <typename T>
+inline uint8_t countTrailingOnes(const register T value);
+
+template <typename T>
+inline uint8_t mostSignificantBit(const register T value);
+
+template <typename T>
+inline uint8_t leastSignificantBit(const register T value);
+
+template <typename T>
+inline uint8_t countOnes(const register T value);
+
+template <>
+inline uint8_t countOnes<uint32_t>(const register uint32_t value);
+
+template <>
+inline uint8_t countOnes<uint64_t>(const register uint64_t value);
+
+template <typename T>
+inline uint8_t countZeros(const register T value);
+
+template <typename T>
+inline uint8_t populationCount(const register T value);
+
+template <typename T>
+inline uint8_t popCount(const register T value);
+
+template <typename T>
+inline bool parity(const register T value);
+
+template <>
+inline bool parity<uint32_t>(const register uint32_t value);
+
+template <>
+inline bool parity<uint64_t>(const register uint64_t value);
+
+}  // namespace reg
+}  // namespace utils
+}  // namespace hunos
+
+#include "register_impl.hpp"
+
+#endif

--- a/base/utils/register/register_impl.hpp
+++ b/base/utils/register/register_impl.hpp
@@ -1,0 +1,131 @@
+#include "register.hpp"
+
+namespace hunos {
+namespace utils {
+inline namespace reg {
+
+template <typename T>
+inline T clearBit(const register T value, const register uint8_t bit){
+	const register T bit_value = (T) (1 << bit);
+	return value & ~bit_value;
+}
+
+template <typename T>
+inline T setBit(const register T value, const register uint8_t bit){
+	const register T bit_value = (T) (1 << bit);
+	return value | bit_value;
+}
+
+template <typename T>
+inline T generateLeadingMask(const register uint8_t start_bit){
+	const register T bit_value = (T) (1 << start_bit);
+	return ~(bit_value - 1);
+}
+
+template <typename T>
+inline T generateTrailingMask(const register uint8_t end_bit){
+	const register T bit_value = (T) (1 << end_bit);
+	return bit_value | (bit_value - 1);
+}
+
+template <typename T>
+inline uint8_t countLeadingZeros(const register T value){
+	register uint32_t expanded_value = ((uint32_t) value) && ((1 << BIT_SIZEOF(T)) - 1);
+	return countLeadingZeros<uint32_t>(expanded_value) - (BIT_SIZEOF(uint32_t) - BIT_SIZEOF(T));
+}
+
+template <>
+inline uint8_t countLeadingZeros<uint32_t>(const register uint32_t value){
+	return __builtin_clz(value);
+}
+
+template <>
+inline uint8_t countLeadingZeros<uint64_t>(const register uint64_t value){
+	return __builtin_clzl(value);
+}
+
+template <typename T>
+inline uint8_t countTrailingZeros(const register T value){
+	return countTrailingZeros<uint32_t>((uint32_t) value);
+}
+
+template <>
+inline uint8_t countTrailingZeros<uint32_t>(const register uint32_t value){
+	return __builtin_ctz(value);
+}
+
+template <>
+inline uint8_t countTrailingZeros<uint64_t>(const register uint64_t value){
+	return __builtin_ctzl(value);
+}
+
+template <typename T>
+inline uint8_t countLeadingOnes(const register T value){
+	return countLeadingZeros<T>(~value);
+}
+
+template <typename T>
+inline uint8_t countTrailingOnes(const register T value){
+	return countTrailingZeros<T>(~value);
+}
+
+template <typename T>
+inline uint8_t mostSignificantBit(const register T value){
+	return BIT_SIZEOF(T) - countLeadingZeros(value) - 1;
+}
+
+template <typename T>
+inline uint8_t leastSignificantBit(const register T value){
+	return countTrailingZeros(value);
+}
+
+template <typename T>
+inline uint8_t countOnes(const register T value){
+	register uint32_t expanded_value = ((uint32_t) value) && ((1 << BIT_SIZEOF(T)) - 1);
+	return countOnes<uint32_t>(expanded_value);
+}
+
+template <>
+inline uint8_t countOnes<uint32_t>(const register uint32_t value){
+	return __builtin_popcount(value);
+}
+
+template <>
+inline uint8_t countOnes<uint64_t>(const register uint64_t value){
+	return __builtin_popcountl(value);
+}
+
+template <typename T>
+inline uint8_t countZeros(const register T value){
+	return countOnes<T>(~value);
+}
+
+template <typename T>
+inline uint8_t populationCount(const register T value){
+	return countOnes<T>(value);
+}
+
+template <typename T>
+inline uint8_t popCount(const register T value){
+	return countOnes<T>(value);
+}
+
+template <typename T>
+inline bool parity(const register T value){
+	register uint32_t expanded_value = ((uint32_t) value) && ((1 << BIT_SIZEOF(T)) - 1);
+	return parity<uint32_t>(expanded_value);
+}
+
+template <>
+inline bool parity<uint32_t>(const register uint32_t value){
+	return __builtin_parity(value);
+}
+
+template <>
+inline bool parity<uint64_t>(const register uint64_t value){
+	return __builtin_parityl(value);
+}
+
+}  // namespace reg
+}  // namespace utils
+}  // namespace hunos


### PR DESCRIPTION
- Added register base inline operations - for register manipulation purpose: set and clear bit, mask generation, counting zeros and ones (all, leading, trailing), parity. For operations gcc built_in functions where used.
- Added register base operations (countOnes, countLeadingZeros, countTrailingZeros and parity) to use when gcc built_in functions are not presented.
