### PR TITLE
Utils base dev - register inline functions update.

### DIFF
--- a/base/utils/register/parity_base_impl.hpp
+++ b/base/utils/register/parity_base_impl.hpp
@@ -10,7 +10,7 @@ template <typename T>
 bool parity(T value){
 	uint8_t ones = countOnes<T>(value);
 
-	return (bool) (ones % 2);
+	return (bool) (ones & 1);
 }
 
 }  // namespace reg

--- a/base/utils/register/register.hpp
+++ b/base/utils/register/register.hpp
@@ -46,10 +46,10 @@ template <typename T>
 inline uint8_t countTrailingOnes(const register T value);
 
 template <typename T>
-inline uint8_t mostSignificantBit(const register T value);
+inline uint8_t mostSignificantSetBit(const register T value);
 
 template <typename T>
-inline uint8_t leastSignificantBit(const register T value);
+inline uint8_t leastSignificantSetBit(const register T value);
 
 template <typename T>
 inline uint8_t countOnes(const register T value);

--- a/base/utils/register/register_impl.hpp
+++ b/base/utils/register/register_impl.hpp
@@ -70,12 +70,12 @@ inline uint8_t countTrailingOnes(const register T value){
 }
 
 template <typename T>
-inline uint8_t mostSignificantBit(const register T value){
+inline uint8_t mostSignificantSetBit(const register T value){
 	return BIT_SIZEOF(T) - countLeadingZeros(value) - 1;
 }
 
 template <typename T>
-inline uint8_t leastSignificantBit(const register T value){
+inline uint8_t leastSignificantSetBit(const register T value){
 	return countTrailingZeros(value);
 }
 


### PR DESCRIPTION
- Changed inline function name from mostSignificantBit to mostSignificantBitSet.
- Changed inline function name from leastSignificantBit to leastSignificantBitSet.
- Changed base parity function to use 'and' operation instead of 'modulo'.